### PR TITLE
fix attribute name

### DIFF
--- a/definitions/rhn_channel.rb
+++ b/definitions/rhn_channel.rb
@@ -4,8 +4,8 @@ define :rhn_channel do
 	channel_name = params[:channel_name]
 	
 	if node['platform_version'].to_i < 7
- 		username = node['cook-rhn']['rhn_user']
-		password = node['cook-rhn']['rhn_pass']
+ 		username = node['rhn-channels']['rhn_user']
+		password = node['rhn-channels']['rhn_pass']
 
 		execute "adding rhn channel #{channel_name}" do
 			command "rhn-channel -a -c #{channel_name} -u #{username} -p #{password}"

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,4 +5,4 @@ license          'MIT'
 description      'Installs/Configures rhn-channels'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 supports 'redhat', ">= 6.0"
-version          '1.1.1'
+version          '1.1.2'


### PR DESCRIPTION
Fixed the name of the rhn_user and rhn_pass attributes which currently renders the rhn_channel resource unusable
