### PR TITLE
Add support for removing channels

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,20 +16,27 @@ rhn_channel "rhel-x86_64-server-optional-6" do
  	channel_name "rhel-x86_64-server-optional-6"
  	username "RHNUSERNAME"
  	password "RHNPASSWORD"
+  action :add
  end
 ```
 Alternatively, you can set **node['rhn-channels']['rhn_user']** and **node['rhn-channels']['rhn_pass']** and simply do:
 ```ruby
 rhn_channel "rhel-x86_64-server-optional-6"
 ```
+To remove a channel:
+```ruby
+rhn_channel "rhel-x86_64-server-optional-6" do
+  action :remove
+end
+```
 Note that you do not need to set your username and password for RHEL 7
 
 TODO
 ----
-* Add support for removing rhn-channels
 * Provide a list of available RHEL channels
 
 License and Authors
 -------------------
 * License: MIT
 * Author: https://github.com/andrewfraley
+* Author: Tenyo Grozev (tenyo.grozev@yale.edu)

--- a/definitions/rhn_channel.rb
+++ b/definitions/rhn_channel.rb
@@ -1,21 +1,39 @@
-define :rhn_channel do
-	params[:channel_name] ||= params[:name]
-	raise "rhn_channel channel_name is nil" if ! params[:channel_name]
-	channel_name = params[:channel_name]
-	
-	if node['platform_version'].to_i < 7
- 		username = node['rhn-channels']['rhn_user']
-		password = node['rhn-channels']['rhn_pass']
+define :rhn_channel, :action => :add do
 
-		execute "adding rhn channel #{channel_name}" do
-			command "rhn-channel -a -c #{channel_name} -u #{username} -p #{password}"
-			not_if "rhn-channel --list | grep '#{channel_name}'"
-		end
-	else
-  		execute "adding subscription-manager repo #{channel_name}" do
-			command "subscription-manager repos --enable=#{channel_name}"
-			not_if "subscription-manager repos --list | grep -A3 #{channel_name} | grep Enabled | awk '{print $2;}' | grep 1"
-		end
-	end
-	
+  params[:channel_name] ||= params[:name]
+  raise "rhn_channel channel_name is nil" if ! params[:channel_name]
+  channel_name = params[:channel_name]
+
+  if node['platform_version'].to_i < 7
+    username = node['rhn-channels']['rhn_user']
+    password = node['rhn-channels']['rhn_pass']
+
+    if params[:action] == :add
+      execute "adding rhn channel #{channel_name}" do
+        command "rhn-channel -a -c #{channel_name} -u #{username} -p #{password}"
+        not_if "rhn-channel --list | grep '#{channel_name}'"
+      end
+
+    elsif params[:action] == :remove
+      execute "removing rhn channel #{channel_name}" do
+        command "rhn-channel -r -c #{channel_name} -u #{username} -p #{password}"
+        only_if "rhn-channel --list | grep '#{channel_name}'"
+      end
+    end
+
+  else
+    if params[:action] == :add
+      execute "adding subscription-manager repo #{channel_name}" do
+        command "subscription-manager repos --enable=#{channel_name}"
+        not_if "subscription-manager repos --list | grep -A3 #{channel_name} | grep Enabled | awk '{print $2;}' | grep 1"
+      end
+
+    elsif params[:action] == :remove
+      execute "adding subscription-manager repo #{channel_name}" do
+        command "subscription-manager repos --disable=#{channel_name}"
+        only_if "subscription-manager repos --list | grep -A3 #{channel_name} | grep Enabled | awk '{print $2;}' | grep 1"
+      end
+    end
+  end
+
 end

--- a/metadata.rb
+++ b/metadata.rb
@@ -5,4 +5,4 @@ license          'MIT'
 description      'Installs/Configures rhn-channels'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
 supports 'redhat', ">= 6.0"
-version          '1.1.2'
+version          '1.2.0'

--- a/recipes/optional_channel.rb
+++ b/recipes/optional_channel.rb
@@ -21,5 +21,6 @@ end
 # 	channel_name "rhel-x86_64-server-optional-6"
 # 	username "RHNUSERNAME"
 # 	password "RHNPASSWORD"
+# 	action :add
 # end
 


### PR DESCRIPTION
- created an action parameter in rhn-channel that can be :add or :remove
- add is the default so existing behavior is unchanged
- tested on RHEL6 but not on RHEL7
